### PR TITLE
Use DefaultAzureCredential if no credentials are supplied

### DIFF
--- a/src/AzureApi/AccessTokenFactory.cs
+++ b/src/AzureApi/AccessTokenFactory.cs
@@ -20,7 +20,7 @@ namespace AzureBillingExporter.AzureApi
             _apiSettings = apiSettings;
             _logger = logger;
             
-            if (string.IsNullOrEmpty(_apiSettings.ClientId))
+            if (!string.IsNullOrEmpty(_apiSettings.ClientId))
             {
                 _logger.LogTrace($"Using client credentials for Client ID ", _apiSettings.ClientId);
                 credentials = new ClientSecretCredential(_apiSettings.TenantId, _apiSettings.ClientId, _apiSettings.ClientSecret);

--- a/src/AzureApi/AccessTokenFactory.cs
+++ b/src/AzureApi/AccessTokenFactory.cs
@@ -1,54 +1,51 @@
-using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
+using Azure.Core;
+using Azure.Identity;
 using AzureBillingExporter.Cost;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace AzureBillingExporter.AzureApi
 {
-    public class AccessTokenFactory: IAccessTokenFactory
+    public class AccessTokenFactory : IAccessTokenFactory
     {
         private readonly ApiSettings _apiSettings;
         private readonly ILogger<BillingQueryClient> _logger;
+        private readonly TokenCredential credentials;
 
         public AccessTokenFactory(
-            ApiSettings apiSettings, 
+            ApiSettings apiSettings,
             ILogger<BillingQueryClient> logger)
         {
             _apiSettings = apiSettings;
             _logger = logger;
+            
+            if (string.IsNullOrEmpty(_apiSettings.ClientId))
+            {
+                _logger.LogTrace($"Using client credentials for Client ID ", _apiSettings.ClientId);
+                credentials = new ClientSecretCredential(_apiSettings.TenantId, _apiSettings.ClientId, _apiSettings.ClientSecret);
+            }
+            else
+            {
+                _logger.LogTrace($"Using default Azure credentials for Teanant ID", _apiSettings.TenantId);
+
+                var credentialOptions = new DefaultAzureCredentialOptions()
+                {
+                    TenantId = _apiSettings.TenantId,
+                    ExcludeInteractiveBrowserCredential = true
+                };
+                credentials = new DefaultAzureCredential(credentialOptions);
+            }
         }
+
         public async Task<string> CreateAsync(CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Into GetBearerToken");
-            var azureAdUrl = $"https://login.microsoftonline.com/{_apiSettings.TenantId}/oauth2/token";
 
-            var resourceEncoded = HttpUtility.UrlEncode("https://management.azure.com");
-            var clientSecretEncoded = HttpUtility.UrlEncode(_apiSettings.ClientSecret);
-            var bodyStr =
-                $"grant_type=client_credentials&client_id={_apiSettings.ClientId}&client_secret={clientSecretEncoded}&resource={resourceEncoded}";
+            var token = await credentials.GetTokenAsync(new TokenRequestContext(new[] { "https://management.azure.com/.default" }), cancellationToken);
+            _logger.LogTrace("Got token {token}", token.Token);
 
-            _logger.LogTrace($"Bearer request bodyStr", bodyStr);
-            var handler = new HttpClientHandler
-            {
-                AllowAutoRedirect = false
-            };
-            using var httpClient = new HttpClient(handler);
-        
-            var response = httpClient.PostAsync(azureAdUrl, 
-                new StringContent(
-                    bodyStr, 
-                    Encoding.UTF8, 
-                    "application/x-www-form-urlencoded"), cancellationToken).Result;
-
-            var responseContent = await response.Content.ReadAsStringAsync();
-            _logger.LogTrace($"Bearer response content {responseContent}");
-            var result = JsonConvert.DeserializeObject<AzureAdResult>(responseContent); 
-
-            return result.access_token;
+            return token.Token;
         }
     }
 }

--- a/src/AzureBillingExporter.csproj
+++ b/src/AzureBillingExporter.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Azure.Identity" Version="1.8.0" />
       <PackageReference Include="Dodo.HttpClient.ResiliencePolicies" Version="2.0.1" />
       <PackageReference Include="DotLiquid" Version="2.0.358" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />


### PR DESCRIPTION
Use DefaultAzureCredential if no credentials are supplied to support managed/local Azure credentials

This allows local debugging with own personal credentials from Visual Studio, Visual Studio Code or Azure CLI. In Azure, this enables Managed Identity for e.g. an Azure Container Instance to consume the Azure Management API.
A big upside is that no credentials must be supplied using app settings or environment variables. Just the Tenant ID must be supplied.