### PR TITLE
Set empty string if labelValue is Null

### DIFF
--- a/src/PrometheusMetrics/CustomMetricsService.cs
+++ b/src/PrometheusMetrics/CustomMetricsService.cs
@@ -60,6 +60,10 @@ namespace AzureBillingExporter.PrometheusMetrics
                 {
                     dataColumnByKeyLabel = DateEnumHelper.ReplaceDateValueToEnums(dataColumnByKeyLabel);
                 }
+                if (dataColumnByKeyLabel == null)
+                {
+                    dataColumnByKeyLabel = "";
+                }
                 labelValues.Add(dataColumnByKeyLabel);
             }
 


### PR DESCRIPTION
If query by tags and tagValue is Null the program is throwing a error with no metrics returned:

## Error output
```
{"@timestamp":"2023-01-25T08:37:56.9361569+00:00","level":"Error","messageTemplate":"Connection id \"{ConnectionId}\", Request id \"{TraceIdentifier}\": An unhandled exception was thrown by the application.","message":"Connection id \"\"0HMNULTQLQ6UK\"\", Request id \"\"0HMNULTQLQ6UK:00000001\"\": An unhandled exception was thrown by the application.","exceptions":[{"Depth":0,"ClassName":"System.ArgumentNullException","Message":"Value cannot be null. (Parameter 'A label value cannot be null.')","Source":"Prometheus.NetStandard","StackTraceString":"   at Prometheus.Labels..ctor(String[] names, String[] values)\n   at Prometheus.Collector`1.Labels(String[] labelValues)\n   at AzureBillingExporter.PrometheusMetrics.CustomMetricsService.SetValues(MetricConfig key, CostResultRows customData) in /app/CustomMetricsService.cs:line 63\n   at AzureBillingExporter.PrometheusMetrics.MetricsUpdater.Update() in /app/MetricsUpdater.cs:line 69\n   at AzureBillingExporter.Startup.<>c__DisplayClass5_0.<Configure>b__0() in /app/Startup.cs:line 94\n   at Prometheus.CollectorRegistry.CollectAndSerializeAsync(IMetricsSerializer serializer, CancellationToken cancel)\n   at Prometheus.MetricServerMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)\n   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)","RemoteStackTraceString":null,"RemoteStackIndex":0,"HResult":-2147467261,"HelpURL":null}],"ConnectionId":"0HMNULTQLQ6UK","TraceIdentifier":"0HMNULTQLQ6UK:00000001","EventId":{"Id":13,"Name":"ApplicationError"},"SourceContex
```

## custom_collectors.yml:
```
metrics:
  - metric_name: azure_billing_by_tags_consultant_monthly
    type: gauge
    help: 'Costs by tag Consultant'
    key_labels:
      - TagValue
    static_labels:
      sub: devtest
    value: PreTaxCost
    replace_date_labels_to_enum: false
    query_file: '/app/custom_queries/azure_billing_by_consultant_tags_monthly.json'
```

## azure_billing_by_consultant_tags_monthly.json:
```
{
  "type": "ActualCost",
  "dataSet": {
    "granularity": "Monthly",
    "aggregation": {
      "totalCost": {
        "name": "PreTaxCost",
        "function": "Sum"
      }
    },
    "grouping": [
      {
        "type": "TagKey",
        "name": "consultant"
      }
    ],
    "sorting": [
      {
        "direction": "ascending",
        "name": "UsageDate"
      }
    ]
  },
  "timeframe": "Custom",
  "timePeriod": {
    "from": "{{ PrevMonthStart }}",
    "to": "{{ CurrentMonthStart }}"
  }
}
```