### PR TITLE
Sre update dot net version 11292742

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.202'
+          dotnet-version: '6.0.412'
 
       - name: Run build
         run:

--- a/AzureBillingExporter.Tests/AzureBillingExporter.Tests.csproj
+++ b/AzureBillingExporter.Tests/AzureBillingExporter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/AzureBillingExporter.Tests/AzureBillingExporter.Tests.csproj
+++ b/AzureBillingExporter.Tests/AzureBillingExporter.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="nunit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0-bullseye-slim AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY ./src/queries/get_daily_or_monthly_costs.json ./queries/get_daily_or_monthl
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/runtime:6.0.20-bullseye-slim
 WORKDIR /app
 EXPOSE 80
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.412",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/AzureBillingExporter.csproj
+++ b/src/AzureBillingExporter.csproj
@@ -7,19 +7,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dodo.HttpClient.ResiliencePolicies" Version="2.0.1" />
-      <PackageReference Include="DotLiquid" Version="2.0.358" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Include="prometheus-net" Version="3.6.0" />
-      <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
-      <PackageReference Include="prometheus-net.AspNetCore.Grpc" Version="3.6.0" />
-      <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="3.6.0" />
-      <PackageReference Include="Serilog" Version="2.10.0" />
-      <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-      <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="8.4.1" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-      <PackageReference Include="YamlDotNet" Version="8.1.2" />
+      <PackageReference Include="Dodo.HttpClient.ResiliencePolicies" Version="2.1.0" />
+      <PackageReference Include="DotLiquid" Version="2.2.692" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="prometheus-net" Version="8.0.1" />
+      <PackageReference Include="prometheus-net.AspNetCore" Version="8.0.1" />
+      <PackageReference Include="prometheus-net.AspNetCore.Grpc" Version="8.0.1" />
+      <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.0.1" />
+      <PackageReference Include="Serilog" Version="3.0.1" />
+      <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+      <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="9.0.3" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+      <PackageReference Include="YamlDotNet" Version="13.1.1" />
     </ItemGroup>
 </Project>

--- a/src/AzureBillingExporter.csproj
+++ b/src/AzureBillingExporter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     </PropertyGroup>


### PR DESCRIPTION
Новые Mac на M1 чипе, на котором не поддерживается .net core 3.1
Также k8s версии 1.25 не поддерживает .Net приложения на 3.1

Поэтому мигрирую проект на .net 6
