### PR TITLE
#11292742 pin version, use aspnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0.412-bullseye-slim AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY ./src/queries/get_daily_or_monthly_costs.json ./queries/get_daily_or_monthl
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/runtime:6.0.20-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.20-bullseye-slim
 WORKDIR /app
 EXPOSE 80
 


### PR DESCRIPTION
Fix
```
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'AzureBillingExporter.dll' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 6.0.412
global.json file: /workdir/global.json

Installed SDKs:
No .NET SDKs were found.

Install the [6.0.412] .NET SDK or update [/workdir/global.json] to match an installed SDK.

Download a .NET SDK:
https://aka.ms/dotnet-download

Learn about SDK resolution:
https://aka.ms/dotnet/sdk-not-found
```